### PR TITLE
メインコンテナのスクロール方法を変更

### DIFF
--- a/components/atoms/buttons/Basic.tsx
+++ b/components/atoms/buttons/Basic.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode, useMemo } from 'react'
 import { ChevronRightIcon } from '@chakra-ui/icons'
 // eslint-disable-next-line import/named
-import { Button, ButtonProps, Spinner } from '@chakra-ui/react'
+import { Box, Button, ButtonProps, Spinner } from '@chakra-ui/react'
 
 type Props = {
   children: ReactNode
@@ -24,6 +24,12 @@ const BasicButton: FC<Props & ButtonProps> = ({
     return undefined
   }, [isNext])
 
+  const leftIcon = useMemo(() => {
+    if (isNext) {
+      return <Box as="span" width="25px" height="25px" />
+    }
+  }, [isNext])
+
   const bg = useMemo(() => {
     return `${theme}.${themeIntensity}`
   }, [theme, themeIntensity])
@@ -35,6 +41,8 @@ const BasicButton: FC<Props & ButtonProps> = ({
       color="white"
       fontWeight={rest.fontWeight || '700'}
       fontSize={rest.fontSize || '16px'}
+      justifyContent="space-between"
+      leftIcon={leftIcon}
       rightIcon={rightIcon}
       py={rest.py || '16px'}
       lineHeight={rest.lineHeight || '23px'}

--- a/components/molecules/questions/Form.tsx
+++ b/components/molecules/questions/Form.tsx
@@ -17,6 +17,10 @@ type Props = {
   questionPage: Questions.Page
 }
 
+interface SendParams extends Profile.Profile {
+  estimate: boolean
+}
+
 const QuestionForm: FC<Props> = ({ questionPage }) => {
   const { profile, setProfile } = useProfile()
 
@@ -71,7 +75,11 @@ const QuestionForm: FC<Props> = ({ questionPage }) => {
   const sendData = useCallback(
     async (data: any) => {
       if (!profile) return
-      const params: Profile.Profile = { ...profile, [sendDataParamsKey]: data }
+      const params: SendParams = {
+        ...profile,
+        [sendDataParamsKey]: data,
+        estimate: questionPage.isLast ? true : false
+      }
       try {
         const { data } = await api.put(`/profiles/${profile?.id}`, params)
         setProfile(data)
@@ -79,7 +87,7 @@ const QuestionForm: FC<Props> = ({ questionPage }) => {
         console.log(error)
       }
     },
-    [profile]
+    [profile, questionPage]
   )
 
   const nextQuestionUid = (data: { [key: string]: string | number }) => {

--- a/components/molecules/questions/Form.tsx
+++ b/components/molecules/questions/Form.tsx
@@ -216,8 +216,9 @@ const QuestionForm: FC<Props> = ({ questionPage }) => {
 
         <Box
           width="90%"
+          maxWidth="100%"
           textAlign="center"
-          position="fixed"
+          position="absolute"
           bottom={5}
           left="50%"
           transform="translateX(-50%)"

--- a/components/organisms/questions/Container.tsx
+++ b/components/organisms/questions/Container.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react'
-import { Box, Container, Text } from '@chakra-ui/react'
+import { Box, Container, Grid, Text } from '@chakra-ui/react'
 import CategoryTitle from 'components/molecules/questions/CategoryTitle'
 
 type Props = {
@@ -9,31 +9,37 @@ type Props = {
 
 const QuestionContainer: FC<Props> = ({ children, category }) => {
   return (
-    <Box
+    <Grid
       backgroundColor={category ? `${category}.200` : 'grey.200'}
-      height="100vh"
+      gridTemplateColumns="100%"
+      gridTemplateRows="auto auto 1fr"
+      minHeight="100vh"
     >
       <Box background="white">
         <Text fontWeight="bold" fontSize="16px" p={4} textAlign="center">
           じぶんごとプラネット
         </Text>
       </Box>
-      <CategoryTitle category={category} />
-      <Box display="flex" justifyContent="center">
+      <Box mb={3}>
+        <CategoryTitle category={category} />
+      </Box>
+      <Box>
         <Container
           background="white"
-          position="fixed"
-          height={{ base: `calc(100vh - ${category ? '180px' : '150px'})` }}
+          height="100%"
           width="90%"
+          maxWidth="736px"
           bottom="0"
           borderRadius="10px 10px 0 0"
           overflow="auto"
           overflowX="hidden"
+          position="relative"
+          px={{ base: 3, md: 10 }}
         >
           <Box pb="40px">{children}</Box>
         </Container>
       </Box>
-    </Box>
+    </Grid>
   )
 }
 

--- a/hooks/emission.ts
+++ b/hooks/emission.ts
@@ -22,10 +22,10 @@ export const useEmissionResult = (
   const calcEmission = useCallback(
     (category: Questions.QuestionCategory) => {
       const result: { key: string; value: number }[] = []
-      const categoryEstimations = profile?.estimations.filter(
+      const categoryEstimations = profile?.estimations?.filter(
         (e) => e.domain === category
       )
-      const categoryBaselines = profile?.baselines.filter(
+      const categoryBaselines = profile?.baselines?.filter(
         (b) => b.domain === category
       )
       const subdomains = uniq(


### PR DESCRIPTION
以前は、中身だけスクロールできるようにしていたが、windowごとスクロールするようにした。
スクリーンレコード
https://www.awesomescreenshot.com/video/10408441?key=63899d53952dbd4c4f401c822376ac7f